### PR TITLE
Fix/max connections exceeded

### DIFF
--- a/ebin/epgsql_pool.app
+++ b/ebin/epgsql_pool.app
@@ -1,6 +1,6 @@
 {application,epgsql_pool,
              [{description,"PostgreSQL Connection Pool"},
-              {vsn,"0.1"},
+              {vsn,"0.1.0"},
               {registered,[]},
               {applications,[kernel,stdlib,epgsql]},
               {mod,{epgsql_pool_app,[]}},

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {deps, [
 	{epgsql, ".*",
-	 {git, "git://github.com/wg/epgsql.git", "HEAD"}}
+	 {git, "git://github.com/SiftLogic/epgsql.git", "devel"}}
        ]}.
 
 %% == Subdirectories ==

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- erlang -*-
-{erl_opts, [debug_info,warnings_as_errors,report,nowarn_unused_vars]}.
+{erl_opts, [debug_info,report,nowarn_unused_vars]}.
 
 %% == Dependencies ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {deps, [
 	{epgsql, ".*",
-	 {git, "git://github.com/SiftLogic/epgsql.git", "devel"}}
+	 {git, "git://github.com/SiftLogic/epgsql.git", {tag, "0.1.0"}}}
        ]}.
 
 %% == Subdirectories ==

--- a/src/epgsql_pool.app.src
+++ b/src/epgsql_pool.app.src
@@ -2,7 +2,7 @@
 {application, epgsql_pool,
  [
   {description, "PostgreSQL Connection Pool"},
-  {vsn, "0.1.2"},
+  {vsn, "0.1.3"},
   {registered, []},
   {applications, [
                   kernel,

--- a/src/epgsql_pool.app.src
+++ b/src/epgsql_pool.app.src
@@ -2,12 +2,12 @@
 {application, epgsql_pool,
  [
   {description, "PostgreSQL Connection Pool"},
-  {vsn, "0.1.3"},
+  {vsn, "0.1.4"},
   {registered, []},
   {applications, [
                   kernel,
                   stdlib,
-		  epgsql
+                  epgsql
                  ]},
   {mod, { epgsql_pool_app, []}},
   {env, [{pools, []}]}

--- a/src/epgsql_pool.app.src
+++ b/src/epgsql_pool.app.src
@@ -2,7 +2,7 @@
 {application, epgsql_pool,
  [
   {description, "PostgreSQL Connection Pool"},
-  {vsn, "0.1"},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,

--- a/src/epgsql_pool.app.src
+++ b/src/epgsql_pool.app.src
@@ -2,7 +2,7 @@
 {application, epgsql_pool,
  [
   {description, "PostgreSQL Connection Pool"},
-  {vsn, "0.1.0"},
+  {vsn, "0.1.2"},
   {registered, []},
   {applications, [
                   kernel,

--- a/src/epgsql_pool_sup.erl
+++ b/src/epgsql_pool_sup.erl
@@ -5,7 +5,7 @@
 
 %% API
 -export([start_link/0,start_link/1]).
--export([start_pool/3]).
+-export([start_pool/3, restart_pool/3]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -36,6 +36,9 @@ start_link() ->
 start_pool(Name, Size, Opts) ->
     supervisor:start_child(?MODULE, [Name, Size, Opts]).
 
+restart_pool(Name, Size, Opts) ->
+    supervisor:restart_child(?MODULE, [Name, Size, Opts]).
+
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
@@ -45,7 +48,7 @@ init([]) ->
      {{simple_one_for_one, 2, 60},
       [{pool,
         {pgsql_pool, start_link, []},
-        permanent, 2000, supervisor,
+        transient, 2000, supervisor,
         [pgsql_pool]}]}}.
 
 %% ===================================================================

--- a/src/epgsql_pool_sup.erl
+++ b/src/epgsql_pool_sup.erl
@@ -48,7 +48,7 @@ init([]) ->
      {{simple_one_for_one, 2, 60},
       [{pool,
         {pgsql_pool, start_link, []},
-        transient, 2000, supervisor,
+        transient, 2000, worker,
         [pgsql_pool]}]}}.
 
 %% ===================================================================

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -2,7 +2,7 @@
 
 -export([start_link/2, start_link/3, stop/1]).
 -export([get_connection/1, get_connection/2, return_connection/2]).
--export([get_database/1, connection_info/1, resize_pool/2]).
+-export([connection_info/1, resize_pool/2]).
 
 -export([init/1, code_change/3, terminate/2]). 
 -export([handle_call/3, handle_cast/2, handle_info/2]).
@@ -53,13 +53,6 @@ get_connection(P, Timeout) ->
 %% @doc Return a db connection back to the connection pool.
 return_connection(P, C) ->
     gen_server:cast(P, {return_connection, C}).
-
-%% @doc Return the name of the database used for the pool.
-get_database(P) ->
-    {ok, C} = get_connection(P),
-    {ok, Db} = pgsql_connection:database(C),
-    return_connection(P, C),
-    {ok, Db}.
 
 connection_info(C) ->
     gen_server:call(C, connection_info).

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -43,7 +43,9 @@ get_connection(P, Timeout) ->
 	try
     	gen_server:call(P, get_connection, Timeout)
 	catch 
-		_:_ ->
+        exit:{noproc, {gen_server, call, _}} ->
+            {error, no_such_pool};
+		exit:{timeout, {gen_server, call, _}} ->
             gen_server:cast(P, {cancel_wait, self()}),
             {error, timeout}
 	end.

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -125,7 +125,12 @@ handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,
 
 
 handle_call({change_timeout, NewTimeout}, _From, #state{opts = Opts0} = State) ->
-    Opts = lists:keyreplace(timeout, 1, Opts0, {timeout, NewTimeout}),
+    Opts = case lists:keyfind(timeout, 1, Opts0) of
+               false ->
+                   [{timeout, NewTimeout} | Opts0];
+               _ ->
+                   lists:keyreplace(timeout, 1, Opts0, {timeout, NewTimeout})
+           end,
     {reply, ok, State#state{opts = Opts}};
 
 %% Trap unsupported calls

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -2,7 +2,7 @@
 
 -export([start_link/2, start_link/3, stop/1]).
 -export([get_connection/1, get_connection/2, return_connection/2]).
--export([connection_info/1, resize_pool/2]).
+-export([connection_info/1, resize_pool/2, change_timeout/2]).
 
 -export([init/1, code_change/3, terminate/2]). 
 -export([handle_call/3, handle_cast/2, handle_info/2]).
@@ -60,6 +60,9 @@ connection_info(C) ->
 resize_pool(C, Size) ->
     gen_server:call(C, {resize_pool, Size}).
 
+change_timeout(C, Timeout) ->
+    gen_server:call(C, {change_timeout, Timeout}).
+
 %% -- gen_server implementation --
 
 init({Name, Size, Opts}) ->
@@ -114,6 +117,11 @@ handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,
     {reply, [{used, length(Monitors)},
              {available, length(Connections)},
              {waiting, queue:len(Waiting)}], State#state{size = NewSize}};
+
+
+handle_call({change_timeout, NewTimeout}, _From, #state{opts = Opts0} = State) ->
+    Opts = lists:keyreplace(timeout, 1, Opts0, {timeout, NewTimeout}),
+    {reply, ok, State#state{opts = Opts}};
 
 %% Trap unsupported calls
 handle_call(Request, _From, State) ->

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -113,7 +113,7 @@ handle_call(connection_info, _From, #state{connections = Connections,
              {size, Size},
              {timeout, case lists:keyfind(timeout, 1, Opts) of
                            false -> 5000;
-                           Timeout -> Timeout
+                           {timeout, Timeout} -> Timeout
                        end}], State};
 
 handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -113,10 +113,15 @@ handle_call(connection_info, _From, #state{connections = Connections,
 
 handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,
                                                   waiting = Waiting,
-                                                  monitors = Monitors} = State) ->
+                                                  monitors = Monitors,
+                                                  opts = Opts} = State) ->
     {reply, [{used, length(Monitors)},
              {available, length(Connections)},
-             {waiting, queue:len(Waiting)}], State#state{size = NewSize}};
+             {waiting, queue:len(Waiting)},
+             {timeout, case lists:keyfind(timeout, 1, Opts) of
+                           false -> 5000;
+                           Timeout -> Timeout
+                       end}], State#state{size = NewSize}};
 
 
 handle_call({change_timeout, NewTimeout}, _From, #state{opts = Opts0} = State) ->

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -93,12 +93,10 @@ handle_call(get_connection, From, #state{connections = Connections, waiting = Wa
 			case length(State#state.monitors) < State#state.size of
 				true ->
 					% Allocate a new connection and return it.
-                    slog:info("Adding new connections: ~p/~p", [length(State#state.monitors)+1,State#state.size]),
 					{ok, C} = connect(State#state.opts),
 				    {noreply, deliver(From, C, State)};
 				false ->
 					% Reached max connections, let the requestor wait
-                    slog:info("At max connections: ~p", [State#state.size]),
 	 				{noreply, State#state{waiting = queue:in(From, Waiting)}}
 			end
     end;

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -105,23 +105,23 @@ handle_call(get_connection, From, #state{connections = Connections, waiting = Wa
 handle_call(connection_info, _From, #state{connections = Connections,
                                            waiting = Waiting,
                                            monitors = Monitors,
-                                           size = Size} = State) ->
+                                           size = Size,
+                                           opts = Opts} = State) ->
     {reply, [{used, length(Monitors)},
              {available, length(Connections)},
              {waiting, queue:len(Waiting)},
-             {size, Size}], State};
-
-handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,
-                                                  waiting = Waiting,
-                                                  monitors = Monitors,
-                                                  opts = Opts} = State) ->
-    {reply, [{used, length(Monitors)},
-             {available, length(Connections)},
-             {waiting, queue:len(Waiting)},
+             {size, Size},
              {timeout, case lists:keyfind(timeout, 1, Opts) of
                            false -> 5000;
                            Timeout -> Timeout
-                       end}], State#state{size = NewSize}};
+                       end}], State};
+
+handle_call({resize_pool, NewSize}, _From, #state{connections = Connections,
+                                                  waiting = Waiting,
+                                                  monitors = Monitors} = State) ->
+    {reply, [{used, length(Monitors)},
+             {available, length(Connections)},
+             {waiting, queue:len(Waiting)}], State#state{size = NewSize}};
 
 
 handle_call({change_timeout, NewTimeout}, _From, #state{opts = Opts0} = State) ->

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -81,7 +81,6 @@ init({Name, Size, Opts}) ->
       monitors    = [],
       waiting     = queue:new(),
       timer       = TRef},
-    io:format("Pool ~p ~p ~p ~n", [Name, Size, Opts]),
     {ok, State}.
 
 %% Requestor wants a connection. When available then immediately return, otherwise add to the waiting queue.

--- a/src/pgsql_pool.erl
+++ b/src/pgsql_pool.erl
@@ -238,5 +238,5 @@ return(C, #state{connections = Connections, monitors = Monitors, waiting = Waiti
 
 %% Return the current time in seconds, used for timeouts.
 now_secs() ->
-    {M,S,_M} = erlang:now(),
+    {M,S,_M} = erlang:timestamp(),
     M*1000 + S.


### PR DESCRIPTION
When the running DB has a max connections smaller than the configured pool size
we crash when trying to open a new connection to add to the pool

Rather add the caller to waiters in this case so system con continue running